### PR TITLE
feat(wait): add simple progress callback

### DIFF
--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,102 @@
+package progress
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/armory-io/kayentactl/pkg/kayenta"
+	"github.com/briandowns/spinner"
+	"github.com/olekukonko/tablewriter"
+)
+
+// GraphicalProgressPrinter implements a kayenta.ProgressFunc
+// that outputs the progress of an analysis while we wait for
+// the final result
+type GraphicalProgressPrinter struct {
+	s         *spinner.Spinner
+	numChecks int
+	out       io.Writer
+}
+
+func NewDefaultGraphicalProgressPrinter() *GraphicalProgressPrinter {
+	return &GraphicalProgressPrinter{
+		s:         spinner.New(spinner.CharSets[9], 100*time.Millisecond),
+		numChecks: 0,
+		out:       os.Stdout,
+	}
+}
+
+func (pp *GraphicalProgressPrinter) PrintProgress(res kayenta.GetStandaloneCanaryAnalysisOutput) {
+	pp.numChecks = pp.numChecks + 1
+	printInPlace(TableStatus(res), pp.numChecks == 1, pp.out)
+}
+
+func (pp *GraphicalProgressPrinter) Start() {
+	pp.s.Start()
+}
+
+func (pp *GraphicalProgressPrinter) Stop() {
+	pp.s.Stop()
+}
+
+func countRune(s string, r rune) int {
+	count := 0
+	for _, c := range s {
+		if c == r {
+			count++
+		}
+	}
+	return count
+}
+
+func printInPlace(o string, createTermSpace bool, out io.Writer) {
+	newLines := countRune(o, '\n')
+	if createTermSpace {
+		for i := 0; i < newLines; i++ {
+			fmt.Fprintln(out)
+		}
+	}
+	fmt.Fprintf(out, "\033[%dA\033[0G\033[0J", newLines)
+	fmt.Fprintf(out, o)
+
+}
+
+func TableStatus(o kayenta.GetStandaloneCanaryAnalysisOutput) string {
+	//termLinesNeeded := len(o.Stages) + fixedTableWriterLines
+
+	// if numChecks == 1 {
+	// 	//create space in terminal for the table
+	// 	for i := 0; i < termLinesNeeded; i++ {
+	// 		fmt.Println()
+	// 	}
+	// }
+	wb := new(bytes.Buffer)
+	table := tablewriter.NewWriter(wb)
+	table.SetHeader([]string{"Name", "TYPE", "STATUS"})
+	table.SetAutoWrapText(false)
+
+	for _, s := range o.Stages {
+		// name := s.Name
+		// if len(name) > 30 {
+		// 	name = name[0:30]
+		// }
+
+		statusColor := tablewriter.Colors{tablewriter.Bold, tablewriter.FgWhiteColor}
+		if s.Status == "RUNNING" {
+			statusColor = tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlueColor}
+		} else if s.Status == "SUCCEEDED" {
+			statusColor = tablewriter.Colors{tablewriter.Bold, tablewriter.FgGreenColor}
+		} else if s.Status == "TERMINAL" {
+			statusColor = tablewriter.Colors{tablewriter.Bold, tablewriter.FgRedColor}
+		}
+		d := []string{s.Name, s.StageType, s.Status}
+		table.Rich(d, []tablewriter.Colors{{}, {}, statusColor})
+	}
+
+	//fmt.Printf("\033[%dA\033[0G\033[0J", termLinesNeeded)
+	table.Render() // Sends bytes to our buffer
+	return wb.String()
+}

--- a/pkg/kayenta/analysis.go
+++ b/pkg/kayenta/analysis.go
@@ -1,13 +1,8 @@
 package kayenta
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"time"
-
-	"github.com/briandowns/spinner"
-	"github.com/olekukonko/tablewriter"
 )
 
 //UpdateScopes is a helper function that will replace the values in an ExecRequest to produce the proper request
@@ -24,77 +19,15 @@ func UpdateScopes(scopes []Scope, scope, startTimeIso, endTimeIso string, contro
 	return updatedScopes
 }
 
-func countRune(s string, r rune) int {
-	count := 0
-	for _, c := range s {
-		if c == r {
-			count++
-		}
-	}
-	return count
-}
-
-func printInPlace(o string, createTermSpace bool) {
-	newLines := countRune(o, '\n')
-	if createTermSpace {
-		for i := 0; i < newLines; i++ {
-			fmt.Println()
-		}
-	}
-	fmt.Printf("\033[%dA\033[0G\033[0J", newLines)
-	fmt.Printf(o)
-
-}
-
-func TableStatus(o GetStandaloneCanaryAnalysisOutput) string {
-	//termLinesNeeded := len(o.Stages) + fixedTableWriterLines
-
-	// if numChecks == 1 {
-	// 	//create space in terminal for the table
-	// 	for i := 0; i < termLinesNeeded; i++ {
-	// 		fmt.Println()
-	// 	}
-	// }
-	wb := new(bytes.Buffer)
-	table := tablewriter.NewWriter(wb)
-	table.SetHeader([]string{"Name", "TYPE", "STATUS"})
-	table.SetAutoWrapText(false)
-
-	for _, s := range o.Stages {
-		// name := s.Name
-		// if len(name) > 30 {
-		// 	name = name[0:30]
-		// }
-
-		statusColor := tablewriter.Colors{tablewriter.Bold, tablewriter.FgWhiteColor}
-		if s.Status == "RUNNING" {
-			statusColor = tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlueColor}
-		} else if s.Status == "SUCCEEDED" {
-			statusColor = tablewriter.Colors{tablewriter.Bold, tablewriter.FgGreenColor}
-		} else if s.Status == "TERMINAL" {
-			statusColor = tablewriter.Colors{tablewriter.Bold, tablewriter.FgRedColor}
-		}
-		d := []string{s.Name, s.StageType, s.Status}
-		table.Rich(d, []tablewriter.Colors{{}, {}, statusColor})
-	}
-
-	//fmt.Printf("\033[%dA\033[0G\033[0J", termLinesNeeded)
-	table.Render() // Sends bytes to our buffer
-	return wb.String()
-}
+type ProgressFunc func(res GetStandaloneCanaryAnalysisOutput)
 
 //WaitForComplete this issues a call out to kayenta and then loops as it waits for it to finish. Likely we'll have to refactor the
 //call signature to inject dependencies, for example, a ticker perhaps should live otuside of this function
-func WaitForComplete(ctx context.Context, executionID string, client StandaloneCanaryAnalysisAPI, ticker *time.Ticker, logger StdLogger) error {
-	if logger == nil {
-		logger = NoopStdLogger{}
-	}
+// progressFunc is called on ever interval where the execution is not complete. if the execution is complete,
+// progressFunc will not be called and the function will terminate.
+func WaitForComplete(ctx context.Context, executionID string, client StandaloneCanaryAnalysisAPI, ticker *time.Ticker, progressFunc ProgressFunc) error {
 	done := make(chan bool, 1)
 	var err1 error
-	numChecks := 0
-
-	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond) // Build our new spinner
-	s.Start()
 
 	go func() {
 		for {
@@ -103,23 +36,20 @@ func WaitForComplete(ctx context.Context, executionID string, client StandaloneC
 				done <- true
 				return
 			case <-ticker.C:
-				//logger.Println("checking on execution status")
 				res, err := client.GetStandaloneCanaryAnalysis(executionID)
 				if err != nil {
-					logger.Println(err.Error())
 					err1 = err
 					done <- true
 					return
 				}
 
 				if res.Complete {
-					s.Stop()
 					done <- true
 					return
 				}
-				numChecks++
-				o := TableStatus(res)
-				printInPlace(o, numChecks == 1)
+				if progressFunc != nil {
+					progressFunc(res)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
adds a simple `ProgressFunc` callback to our wait function. this allows
callers of the library to implement progress however they want. for
example, i've extracted the existing progress code into a struct that
implements a progress func for pretty printing the progress as we go.