### PR TITLE
chore(config): support local files as well as http

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/armory/plank/v3 v3.4.3
 	github.com/briandowns/spinner v1.12.0
 	github.com/fatih/color v1.7.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/strfmt v0.19.11 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/mattn/go-runewidth v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/internal/canaryConfig/provider.go
+++ b/internal/canaryConfig/provider.go
@@ -1,0 +1,60 @@
+package canaryConfig
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/armory-io/kayentactl/pkg/kayenta"
+)
+
+// GetCanaryConfig fetches a canary config from a remote or local source
+// and converts it to a StandaloneCanaryAnalysisInput. It supports both YAML
+// and JSON data formats
+func GetCanaryConfig(location string) (*kayenta.StandaloneCanaryAnalysisInput, error) {
+	var configProvider func(string) ([]byte, error)
+	if startsWithProtocol(location, []string{"file://", "http://", "https://"}) {
+		configProvider = httpConfigProvider
+	} else {
+		configProvider = ioutil.ReadFile
+	}
+
+	b, err := configProvider(location)
+	if err != nil {
+		return nil, err
+	}
+
+	var input kayenta.StandaloneCanaryAnalysisInput
+	if err := parseYamlOrJson(b, &input); err != nil {
+		return nil, fmt.Errorf("failed to deserialize canary config: %w", err)
+	}
+	return &input, nil
+}
+
+func httpConfigProvider(location string) ([]byte, error) {
+	resp, err := http.Get(location)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("attempt to fetch config results in code %d", resp.StatusCode)
+	}
+	return ioutil.ReadAll(resp.Body)
+}
+
+func startsWithProtocol(location string, protocols []string) bool {
+	for _, p := range protocols {
+		if strings.HasPrefix(location, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseYamlOrJson(b []byte, dest interface{}) error {
+	return yaml.Unmarshal(b, dest)
+}


### PR DESCRIPTION
support http and local file sourcing for canary configurations. also,
support both YAML and JSON as input data formats.