### PR TITLE
chore(options): decouple exec request & config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,32 +26,17 @@ and Memory utilization.
 <p>
 
 ```yaml
-executionRequest:
-  lifetimeDurationMins: 10
-  analysisIntervalMins: 1
-  scopes:
-  - controlScope: host:gke-armory-shared-ser-devops-gke-test-96cd73b4-zr3q.c.shared-services-pb.internal
-    controlOffset: 0
-    experimentScope: host:gke-armory-shared-ser-devops-gke-test-96cd73b4-10cz.c.shared-services-pb.internal
-    extendedScopeParams:
-      application: datadog-cn
-    scopeName: default
-    step: 300
-  thresholds:
-    marginal: "0"
-    pass: "99"
-canaryConfig:
-  classifier:
-    groupWeights:
-      MEM: 40
-      CPU: 35
-      IO: 25
-  configVersion: "1"
-  judge:
-    name: NetflixACAJudge-v1.0
-  metrics:
+classifier:
+  groupWeights:
+    MEM: 40
+    CPU: 35
+    IO: 25
+configVersion: "1"
+judge:
+  name: NetflixACAJudge-v1.0
+metrics:
   - groups:
-    - MEM
+      - MEM
     name: mem-rss
     query:
       metricName: max:docker.mem.rss
@@ -59,7 +44,7 @@ canaryConfig:
       type: datadog
     scopeName: default
   - groups:
-    - MEM
+      - MEM
     name: mem-in-use
     query:
       metricName: max:docker.mem.in_use
@@ -67,7 +52,7 @@ canaryConfig:
       type: datadog
     scopeName: default
   - groups:
-    - CPU
+      - CPU
     name: cpu-total
     query:
       metricName: avg:docker.cpu.usage
@@ -75,7 +60,7 @@ canaryConfig:
       type: datadog
     scopeName: default
   - groups:
-    - CPU
+      - CPU
     name: cpu-sys
     query:
       metricName: avg:docker.cpu.system
@@ -83,7 +68,7 @@ canaryConfig:
       type: datadog
     scopeName: default
   - groups:
-    - CPU
+      - CPU
     name: cpu-user
     query:
       metricName: avg:docker.cpu.user
@@ -91,7 +76,7 @@ canaryConfig:
       type: datadog
     scopeName: default
   - groups:
-    - CPU
+      - CPU
     name: cpu-threads
     query:
       metricName: max:docker.thread.count
@@ -99,7 +84,7 @@ canaryConfig:
       type: datadog
     scopeName: default
   - groups:
-    - IO
+      - IO
     name: io-bytes-rcvd
     query:
       metricName: avg:docker.net.bytes_rcvd
@@ -107,18 +92,29 @@ canaryConfig:
       type: datadog
     scopeName: default
   - groups:
-    - IO
+      - IO
     name: io-bytes-sent
     query:
       metricName: avg:docker.net.bytes_rcvd
       serviceType: datadog
       type: datadog
     scopeName: default
-  name: democonfig
+name: democonfig
+
 ```
 
 </p>
 </details>
+
+### Perform a retrospective analysis over a specific time period (typically in the past)
+_Note: the `scope` below represents a namespace and deployment name, separated by a `/`._
+```shell
+kayentactl analysis start --scope=production/webserver \
+  --start-time-iso 2021-02-24T15:00:00Z \
+  --end-time-iso 2021-02-25T15:00:00Z \
+  --canary-config config.yml \
+  --thresholds marginal=50,pass=90
+```
 
 ### Simple usage with default canary configuration
 ```shell

--- a/examples/config/newrelic/canaryConfig.yml
+++ b/examples/config/newrelic/canaryConfig.yml
@@ -1,0 +1,32 @@
+name: test-canary-config
+description: An sample canary configuration for use with New Relic
+configVersion: "1"
+applications:
+  - ad-hoc
+judge:
+  name: NetflixACAJudge-v1.0
+  judgeConfigurations: {}
+metrics:
+  - name: Server error count
+    query:
+      type: newrelic
+      q: "status >= '500'"
+      select: SELECT count(http_server_requests) FROM Metric
+      serviceType: newrelic
+    groups:
+      - Errors
+    analysisConfigurations:
+      canary:
+        critical: false
+        nanStrategy: remove
+        effectSize:
+          allowedIncrease: 1
+          allowedDecrease: 1
+        outliers:
+          strategy: keep
+        direction: either
+    scopeName: default
+templates: {}
+classifier:
+  groupWeights:
+    Errors: 100

--- a/internal/canaryConfig/provider.go
+++ b/internal/canaryConfig/provider.go
@@ -14,7 +14,7 @@ import (
 // GetCanaryConfig fetches a canary config from a remote or local source
 // and converts it to a StandaloneCanaryAnalysisInput. It supports both YAML
 // and JSON data formats
-func GetCanaryConfig(location string) (*kayenta.StandaloneCanaryAnalysisInput, error) {
+func GetCanaryConfig(location string) (*kayenta.CanaryConfig, error) {
 	var configProvider func(string) ([]byte, error)
 	if startsWithProtocol(location, []string{"file://", "http://", "https://"}) {
 		configProvider = httpConfigProvider
@@ -27,7 +27,7 @@ func GetCanaryConfig(location string) (*kayenta.StandaloneCanaryAnalysisInput, e
 		return nil, err
 	}
 
-	var input kayenta.StandaloneCanaryAnalysisInput
+	var input kayenta.CanaryConfig
 	if err := parseYamlOrJson(b, &input); err != nil {
 		return nil, fmt.Errorf("failed to deserialize canary config: %w", err)
 	}

--- a/pkg/kayenta/client.go
+++ b/pkg/kayenta/client.go
@@ -48,7 +48,11 @@ type Metric struct {
 	Name      string            `json:"name"`
 	Query     map[string]string `json:"query"`
 	ScopeName string            `json:"scopeName"`
+
+	AnalysisConfigurations AnalysisConfiguration `json:"analysisConfigurations"`
 }
+
+type AnalysisConfiguration map[string]interface{}
 
 type CanaryClassifier struct {
 	GroupWeights map[string]int `json:"groupWeights"`


### PR DESCRIPTION
decouples the execution request from the config. this enables users to
use a single canary config across multiple executions. the execution
request (control/experiment group, lifetime, etc) is created from all of
the CLI args while the canary config is still sourced from disk