### PR TITLE
feat(accounts): list available accounts

### DIFF
--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -1,0 +1,31 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// analysisCmd represents the analysis command
+var accountsCmd = &cobra.Command{
+	Use:   "accounts",
+	Short: "commands for interacting with the accounts API",
+	Long:  ``,
+}
+
+func init() {
+	RootCmd().AddCommand(accountsCmd)
+}

--- a/cmd/accounts_list.go
+++ b/cmd/accounts_list.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/armory-io/kayentactl/pkg/kayenta"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var types string
+
+var shorthandMap = map[string]string{
+	"metrics": "METRICS_STORE",
+	"config":  "CONFIGURATION_STORE",
+	"object":  "OBJECT_STORE",
+}
+
+// getCmd represents the get command
+var accountListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		kc := kayenta.NewDefaultClient(kayenta.ClientBaseURL(kayentaURL))
+		credentials, err := kc.GetCredentials()
+		if err != nil {
+			log.Fatalf("could not get list of available accounts: %s", err.Error())
+		}
+
+		// TODO: add type filtering
+
+		var (
+			output []byte
+		)
+		switch outFormat {
+		case "json":
+			output, err = outputJson(credentials)
+		case "pretty":
+			// TODO: implement a pretty output instead of just falling back to json
+			output, err = outputPretty(credentials)
+		}
+
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+
+		fmt.Fprint(os.Stdout, string(output))
+	},
+}
+
+func outputJson(creds []kayenta.AccountCredential) ([]byte, error) {
+	return json.MarshalIndent(creds, "", "  ")
+}
+
+func outputPretty(creds []kayenta.AccountCredential) ([]byte, error) {
+	return outputJson(creds)
+}
+
+func init() {
+	accountsCmd.AddCommand(accountListCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	getCmd.Flags().StringVarP(&types, "types", "t", "", "filter by account type")
+
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,10 @@ func Execute() {
 	}
 }
 
+func RootCmd() *cobra.Command {
+	return rootCmd
+}
+
 func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/pkg/kayenta/client.go
+++ b/pkg/kayenta/client.go
@@ -13,6 +13,7 @@ import (
 const (
 	canaryConfigEndpoint             = "/canaryConfig"
 	standaloneCanaryAnalysisEndpoint = "/standalone_canary_analysis"
+	credentialsEndpoint              = "/credentials"
 )
 
 //StandaloneCanaryAnalysisInput is used to create an api request to kayenta for a standalone analysis
@@ -169,9 +170,20 @@ type StandaloneCanaryAnalysisAPI interface {
 	GetStandaloneCanaryAnalysis(id string) (GetStandaloneCanaryAnalysisOutput, error)
 }
 
+type CredentialsAPI interface {
+	GetCredentials() []AccountCredential
+}
+
+type AccountCredential struct {
+	Name           string   `json:"name"`
+	SupportedTypes []string `json:"supportedTypes"`
+	Type           string   `json:"type"`
+}
+
 type Client interface {
 	StandaloneCanaryAnalysisAPI
 	CanaryConfigAPI
+	CredentialsAPI
 }
 
 // HTTPClientFactory returns an http.Client that
@@ -359,6 +371,24 @@ func (d *DefaultClient) GetCanaryConfigs(application string) ([]CanaryConfig, er
 		return nil, err
 	}
 	var output []CanaryConfig
+	if err := deserializeResponse(resp, &output); err != nil {
+		return nil, err
+	}
+	return output, nil
+
+}
+
+func (d *DefaultClient) GetCredentials() ([]AccountCredential, error) {
+	req, err := http.NewRequest(
+		http.MethodGet, d.getEndpoint(credentialsEndpoint, nil), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := d.ClientFactory().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	var output []AccountCredential
 	if err := deserializeResponse(resp, &output); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
add a subcommand for listing available accounts. this is useful if you
have multiple accounts hooked into the same system.