### PR TITLE
chore(organization): reorganize commands

### DIFF
--- a/cmd/accounts/accounts.go
+++ b/cmd/accounts/accounts.go
@@ -13,19 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package accounts
 
 import (
 	"github.com/spf13/cobra"
 )
 
 // analysisCmd represents the analysis command
-var analysisCmd = &cobra.Command{
-	Use:   "analysis",
-	Short: "commands for interacting with canary analysis like starting or retrieving an analysis",
+var accountsCmd = &cobra.Command{
+	Use:   "accounts",
+	Short: "commands for interacting with the accounts API",
 	Long:  ``,
 }
 
-func init() {
-	rootCmd.AddCommand(analysisCmd)
+func Configure(cmd *cobra.Command) {
+	cmd.AddCommand(accountsCmd)
 }

--- a/cmd/accounts/accounts_list.go
+++ b/cmd/accounts/accounts_list.go
@@ -1,16 +1,20 @@
-package cmd
+package accounts
 
 import (
 	"encoding/json"
 	"fmt"
 	"os"
 
+	"github.com/armory-io/kayentactl/internal/options"
+
 	"github.com/armory-io/kayentactl/pkg/kayenta"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var types string
+var (
+	types, outFormat string
+)
 
 var shorthandMap = map[string]string{
 	"metrics": "METRICS_STORE",
@@ -24,7 +28,8 @@ var accountListCmd = &cobra.Command{
 	Short: "",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		kc := kayenta.NewDefaultClient(kayenta.ClientBaseURL(kayentaURL))
+		globals, _ := options.Globals(cmd)
+		kc := kayenta.NewDefaultClient(kayenta.ClientBaseURL(globals.KayentaURL))
 		credentials, err := kc.GetCredentials()
 		if err != nil {
 			log.Fatalf("could not get list of available accounts: %s", err.Error())
@@ -61,16 +66,7 @@ func outputPretty(creds []kayenta.AccountCredential) ([]byte, error) {
 
 func init() {
 	accountsCmd.AddCommand(accountListCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	getCmd.Flags().StringVarP(&types, "types", "t", "", "filter by account type")
+	accountListCmd.Flags().StringVarP(&types, "types", "t", "", "filter by account type")
+	accountListCmd.Flags().StringVarP(&outFormat, "output", "o", "pretty", "output format: json|pretty")
 
 }

--- a/cmd/analysis/analysis.go
+++ b/cmd/analysis/analysis.go
@@ -13,19 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package analysis
 
 import (
 	"github.com/spf13/cobra"
 )
 
 // analysisCmd represents the analysis command
-var accountsCmd = &cobra.Command{
-	Use:   "accounts",
-	Short: "commands for interacting with the accounts API",
+var analysisCmd = &cobra.Command{
+	Use:   "analysis",
+	Short: "commands for interacting with canary analysis like starting or retrieving an analysis",
 	Long:  ``,
 }
 
-func init() {
-	RootCmd().AddCommand(accountsCmd)
+func Configure(cmd *cobra.Command) {
+	cmd.AddCommand(analysisCmd)
 }

--- a/cmd/analysis/get.go
+++ b/cmd/analysis/get.go
@@ -13,10 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package analysis
 
 import (
 	"os"
+
+	"github.com/armory-io/kayentactl/internal/options"
 
 	"github.com/armory-io/kayentactl/internal/report"
 
@@ -33,7 +35,9 @@ var getCmd = &cobra.Command{
 	Short: "",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		kc := kayenta.NewDefaultClient(kayenta.ClientBaseURL(kayentaURL))
+		globals, _ := options.Globals(cmd)
+
+		kc := kayenta.NewDefaultClient(kayenta.ClientBaseURL(globals.KayentaURL))
 		executionID := args[0]
 		if executionID == "" {
 			log.Fatal("execution id is required")

--- a/cmd/analysis/start.go
+++ b/cmd/analysis/start.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package analysis
 
 import (
 	"context"
@@ -21,6 +21,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/armory-io/kayentactl/internal/options"
 
 	"github.com/armory-io/kayentactl/internal/canaryConfig"
 
@@ -74,10 +76,12 @@ var startCmd = &cobra.Command{
 	Short: "",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		if !noColor {
+		globals, _ := options.Globals(cmd)
+
+		if !globals.NoColor {
 			fmt.Printf("%v\n", color.HiMagentaString(report.AsciiKayenta))
 		}
-		kc := kayenta.NewDefaultClient(kayenta.ClientBaseURL(kayentaURL))
+		kc := kayenta.NewDefaultClient(kayenta.ClientBaseURL(globals.KayentaURL))
 
 		log.Debugf("Fetching canary config from: %s", color.BlueString(configLocation))
 		canaryConfig, err := canaryConfig.GetCanaryConfig(configLocation)
@@ -113,7 +117,7 @@ var startCmd = &cobra.Command{
 		}
 
 		// start standalone canary
-		log.Debugf("Analysis Execution starting with kayenta host: %v", color.BlueString(kayentaURL))
+		log.Debugf("Analysis Execution starting with kayenta host: %v", color.BlueString(globals.KayentaURL))
 		output, err := kc.StartStandaloneCanaryAnalysis(input)
 		if err != nil {
 			log.Fatalf("error starting canary analysis: %s", err.Error())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,12 @@ package cmd
 import (
 	"os"
 
+	"github.com/armory-io/kayentactl/internal/options"
+
+	"github.com/armory-io/kayentactl/cmd/accounts"
+
+	"github.com/armory-io/kayentactl/cmd/analysis"
+
 	"github.com/armory-io/kayentactl/internal/logger"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -68,16 +74,13 @@ func Execute() {
 	}
 }
 
-func RootCmd() *cobra.Command {
-	return rootCmd
-}
-
 func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	rootCmd.PersistentFlags().StringVarP(&kayentaURL, "kayenta-url", "u", "http://localhost:8090", "kayenta url")
-	rootCmd.PersistentFlags().StringVarP(&verbosity, "verbosity", "v", log.InfoLevel.String(), "log level (debug, info, warn, error, fatal, panic)")
-	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable output colors")
+	analysis.Configure(rootCmd)
+	accounts.Configure(rootCmd)
+	rootCmd.AddCommand()
+	// global options are added by an external pacakge so that they can be
+	// managed from a single source and used across all sub-commands. this
+	// ensures that the logic for getting then stays consistent
+	options.ConfigureGlobals(rootCmd)
 
 }

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -1,0 +1,32 @@
+package options
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func ConfigureGlobals(cmd *cobra.Command) {
+	persistentFlags := cmd.PersistentFlags()
+	persistentFlags.StringP("kayenta-url", "u", "http://localhost:8090", "kayenta url")
+	persistentFlags.StringP("verbosity", "v", log.InfoLevel.String(), "log level (debug, info, warn, error, fatal, panic)")
+	persistentFlags.Bool("no-color", false, "disable output colors")
+}
+
+type GlobalOptions struct {
+	KayentaURL, Verbosity string
+	NoColor               bool
+}
+
+func Globals(cmd *cobra.Command) (*GlobalOptions, error) {
+	flags := cmd.PersistentFlags()
+
+	kayentaURL, _ := flags.GetString("kayenta-url")
+	verbosity, _ := flags.GetString("verbosity")
+	noColor, _ := flags.GetBool("no-color")
+
+	return &GlobalOptions{
+		KayentaURL: kayentaURL,
+		Verbosity:  verbosity,
+		NoColor:    noColor,
+	}, nil
+}


### PR DESCRIPTION
reoragnize commands to make the process of adding new subcommands
easier. adds a global options package and a new `Configure` method
across subcommands to discourage the use of globals.